### PR TITLE
ext4_utils: Yet another MMC discard pain in the ass

### DIFF
--- a/ext4_utils/wipe.c
+++ b/ext4_utils/wipe.c
@@ -42,10 +42,12 @@ int wipe_block_device(int fd, s64 len)
 		return 0;
 	}
 
+#ifndef NO_SECURE_DISCARD
 	range[0] = 0;
 	range[1] = len;
 	ret = ioctl(fd, BLKSECDISCARD, &range);
 	if (ret < 0) {
+#endif
 		range[0] = 0;
 		range[1] = len;
 		ret = ioctl(fd, BLKDISCARD, &range);
@@ -56,8 +58,9 @@ int wipe_block_device(int fd, s64 len)
 			warn("Wipe via secure discard failed, used discard instead\n");
 			return 0;
 		}
+#ifndef NO_SECURE_DISCARD
 	}
-
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
 * Secure discard on this device is painfully slow. Use regular
   discard until the issue is sorted out.

Change-Id: Ib8ccb12829385aa267253f772e243bef8850f455